### PR TITLE
Add health checks to Swagger.

### DIFF
--- a/CleaningRobotService.Web/CleaningRobotService.Web.csproj
+++ b/CleaningRobotService.Web/CleaningRobotService.Web.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
-        <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.14" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
         <PackageReference Include="System.Text.Json" Version="6.0.6" />

--- a/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthReportDto.cs
+++ b/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthReportDto.cs
@@ -1,0 +1,27 @@
+﻿namespace CleaningRobotService.Web.ControllerGroups.Health.Dtos;
+
+/// <remarks>
+/// Have to map <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport"/> because it eventually contains an Exception which cannot be serialized.
+/// </remarks>
+public class HealthReportDto
+{
+    /// <summary>
+    /// A <see cref="IReadOnlyDictionary{TKey, T}"/> containing the results from each health check.
+    /// </summary>
+    /// <remarks>
+    /// The keys in this dictionary map the name of each executed health check to a <see cref="HealthReportEntryDto"/> for the
+    /// result data returned from the corresponding health check.
+    /// </remarks>
+    public IReadOnlyDictionary<string, HealthReportEntryDto>? Entries { get; set; }
+
+    /// <summary>
+    /// A <see cref="HealthStatusDto"/> representing the aggregate status of all the health checks. The value of <see cref="Status"/>
+    /// will be the most severe status reported by a health check. If no checks were executed, the value is always <see cref="HealthStatusDto.Healthy"/>.
+    /// </summary>
+    public HealthStatusDto Status { get; set; }
+
+    /// <summary>
+    /// Time the health check service took to execute.
+    /// </summary>
+    public TimeSpan TotalDuration { get; set; }
+}

--- a/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthReportEntryDto.cs
+++ b/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthReportEntryDto.cs
@@ -1,0 +1,29 @@
+﻿namespace CleaningRobotService.Web.ControllerGroups.Health.Dtos;
+
+public struct HealthReportEntryDto
+{
+    /// <summary>
+    /// Additional key-value pairs describing the health of the component.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Data { get; set; }
+
+    /// <summary>
+    /// Human-readable description of the status of the component that was checked.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Health check execution duration.
+    /// </summary>
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>
+    /// Health status of the component that was checked.
+    /// </summary>
+    public HealthStatusDto Status { get; set; }
+
+    /// <summary>
+    /// Tags associated with the health check.
+    /// </summary>
+    public IEnumerable<string> Tags { get; set; }
+}

--- a/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthStatusDto.cs
+++ b/CleaningRobotService.Web/ControllerGroups/Health/Dtos/HealthStatusDto.cs
@@ -1,0 +1,33 @@
+﻿namespace CleaningRobotService.Web.ControllerGroups.Health.Dtos;
+
+/// <summary>
+/// Represents the reported status of a health check result.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A status of <see cref="Unhealthy"/> should be considered the default value for a failing health check. Application
+/// developers may configure a health check to report a different status as desired.
+/// </para>
+/// <para>
+/// The values of this enum or ordered from least healthy to most healthy. So <see cref="HealthStatusDto.Degraded"/> is
+/// greater than <see cref="HealthStatusDto.Unhealthy"/> but less than <see cref="HealthStatusDto.Healthy"/>.
+/// </para>
+/// </remarks>
+public enum HealthStatusDto
+{
+    /// <summary>
+    /// Indicates that the health check determined that the component was unhealthy, or an unhandled
+    /// exception was thrown while executing the health check.
+    /// </summary>
+    Unhealthy = 0,
+
+    /// <summary>
+    /// Indicates that the health check determined that the component was in a degraded state.
+    /// </summary>
+    Degraded = 1,
+
+    /// <summary>
+    /// Indicates that the health check determined that the component was healthy.
+    /// </summary>
+    Healthy = 2,
+}

--- a/CleaningRobotService.Web/ControllerGroups/Health/HealthController.cs
+++ b/CleaningRobotService.Web/ControllerGroups/Health/HealthController.cs
@@ -1,0 +1,41 @@
+﻿using System.Net;
+using CleaningRobotService.Web.ControllerGroups.Health.Dtos;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CleaningRobotService.Web.ControllerGroups.Health;
+
+[Route("/health")]
+public class HealthController : Controller
+{
+    private readonly HealthCheckService _healthCheckService;
+    private readonly IWebHostEnvironment _hostingEnvironment;
+    
+    public HealthController(HealthCheckService healthCheckService, IWebHostEnvironment hostingEnvironment)
+    {
+        _healthCheckService = healthCheckService;
+        _hostingEnvironment = hostingEnvironment;
+    }
+     
+    /// <summary>
+    /// Get health.
+    /// </summary>
+    /// <remarks>Provides an indication about the health of the API</remarks>
+    /// <response code="200">API is healthy</response>
+    /// <response code="503">API is unhealthy or in degraded state</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(HealthReportDto), (int)HttpStatusCode.OK)]
+    public async Task<IActionResult> Get()
+    {
+        var report = await _healthCheckService.CheckHealthAsync();
+
+        if (_hostingEnvironment.IsDevelopment())
+        {
+            return report.Status == HealthStatus.Healthy
+                ? Ok(report.ToDto())
+                : StatusCode((int)HttpStatusCode.ServiceUnavailable, report.ToDto());
+        }
+        
+        return report.Status == HealthStatus.Healthy ? Ok("Healthy") : StatusCode((int)HttpStatusCode.ServiceUnavailable, "Unhealthy");
+    }
+}

--- a/CleaningRobotService.Web/ControllerGroups/Health/HealthMapper.cs
+++ b/CleaningRobotService.Web/ControllerGroups/Health/HealthMapper.cs
@@ -1,0 +1,29 @@
+﻿using CleaningRobotService.Web.ControllerGroups.Health.Dtos;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CleaningRobotService.Web.ControllerGroups.Health;
+
+public static class HealthMapper
+{
+    public static HealthReportDto ToDto(this HealthReport healthReport) => new()
+    {
+        Entries = healthReport.Entries.ToDtos(),
+        Status = healthReport.Status.ToDto(),
+        TotalDuration = healthReport.TotalDuration,
+    };
+
+    private static HealthReportEntryDto ToDto(this HealthReportEntry healthReportEntry) => new HealthReportEntryDto
+    {
+        Data = healthReportEntry.Data,
+        Status = healthReportEntry.Status.ToDto(),
+        Description = healthReportEntry.Description,
+        Duration = healthReportEntry.Duration,
+        Tags = healthReportEntry.Tags,
+    };
+    
+    private static IReadOnlyDictionary<string, HealthReportEntryDto> ToDtos(this IReadOnlyDictionary<string, HealthReportEntry> healthReportEntries) =>
+        healthReportEntries.ToDictionary(x => x.Key, x => x.Value.ToDto());
+    
+    private static HealthStatusDto ToDto(this HealthStatus healthStatus)
+        => (HealthStatusDto)Enum.Parse(typeof(HealthStatusDto), healthStatus.ToString());
+}

--- a/CleaningRobotService.Web/Program.cs
+++ b/CleaningRobotService.Web/Program.cs
@@ -3,8 +3,6 @@ using CleaningRobotService.BusinessLogic;
 using CleaningRobotService.DataPersistence;
 using CleaningRobotService.Web;
 using CleaningRobotService.Web.Filters;
-using HealthChecks.UI.Client;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 
 WebApplication
@@ -80,8 +78,6 @@ namespace CleaningRobotService.Web
 
             app.MapControllers();
 
-            app.UseHealth();
-
             return app;
         }
     
@@ -95,20 +91,6 @@ namespace CleaningRobotService.Web
             app.Logger.LogInformation("Running database migrations.");
             database.Migrate();
             app.Logger.LogInformation("Finished running database migrations.");
-        }
-
-        private static void UseHealth(this WebApplication app)
-        {
-            var options = new HealthCheckOptions();
-
-            // Hide detailed information unless in development.
-            if (app.Environment.IsDevelopment())
-            {
-                options.Predicate = _ => true;
-                options.ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse;
-            }
-            
-            app.UseHealthChecks(path: "/health-check", options: options);
         }
     }
 }


### PR DESCRIPTION
Health checks now show in Swagger:

![image](https://user-images.githubusercontent.com/7733459/221248262-67319b03-7fe2-40bb-9dbe-b5c6b19b6696.png)

Tried using https://stackoverflow.com/a/59211235 but the exception can't be serialized causing issues when a service cannot be reached.